### PR TITLE
Workshop and documentation contributor guide updates (#354)

### DIFF
--- a/docs/contribute/documentation.md
+++ b/docs/contribute/documentation.md
@@ -229,15 +229,27 @@ The Admonitions supported by the Material theme are :
 
 To work on documentation and be able to view the rendered web site you need to create an environment, which comprises of:
 
-- Install [Python 3](https://www.python.org) on your system
-- Clone or Fork the documentation repository
-- cd into the documentation directory
-- Install the required python packages `pip install -r requirements.txt'
+=== "Local tooling installation"
 
-You now have all the tools installed to be able to create the static HTML site from the markdown documents.  The [documentation for MkDocs](https://www.mkdocs.org) provides full instructions for using MkDocs, but the important commands are:
+    You can install MkDocs and associated plugins on your development system and run the tools locally:
 
-- `mkdocs build` will build the static site.  This must be run in the root directory of the repo, where mkdocs.yml is located
-- `mkdocs serve` will build the static site and launch a test server on http://localhost:8000.  Everytime a document is modified the website will automatically be updated and any browser open will be refreshed to the latest.
+    - Install [Python 3](https://www.python.org) on your system
+    - Clone or Fork the documentation repository
+    - cd into the documentation directory
+    - Install the required python packages `pip install -r requirements.txt'
 
-!!!Warning
-    Within the configuration mkdocs is configured to fail with internal broken links.  This will also kill the local test server.  If you want to disable this functionality change the **strict** value in mkdocs.yml from `strict: true` to `strict: false`.  Do not check in mkdocs.yaml with strict disabled, as we don't want to publish broken documentation!
+    You now have all the tools installed to be able to create the static HTML site from the markdown documents.  The [documentation for MkDocs](https://www.mkdocs.org) provides full instructions for using MkDocs, but the important commands are:
+
+    - `mkdocs build` will build the static site.  This must be run in the root directory of the repo, where mkdocs.yml is located
+    - `mkdocs serve` will build the static site and launch a test server on [http://localhost:8000](http://localhost:8000){: target=_blank}.  Everytime a document is modified the website will automatically be updated and any browser open will be refreshed to the latest.
+
+=== "Tooling within a Docker container"
+
+    You can use a Docker container and run MkDocs from the container, so no local installation is required:
+
+    - You need to have [Docker](https://www.docker.com) installed and running on your system
+    - There are helper configurations installed if you have npm from [Node.JS](https://nodejs.org) installed.
+    - To start developing run command `npm run dev` in the root directory of the git repo (where **package.json** and **mkdocs.yaml** are located)
+    - Open a browser to [http://localhost:8000](http://localhost:8000){: target=_blank}, where you will see the documentation site.  This will live update as you save changes to the Markdown files in the docs folder
+    - To stop developing run command `npm dev:stop`, which will terminate the docker container
+    - View the scripts section of **package.json** in the root folder of the git repo for additional options available

--- a/docs/resources/workshop/appmod.md
+++ b/docs/resources/workshop/appmod.md
@@ -12,9 +12,14 @@ This section will cover:
 
 ---
 
+!!!Todo
+    Fixup links - make relative when setup sections have been completed
+
+    how do windows users do the workshop?
+
 1. Prerequisites
 
-    - The instructor should [Setup Workshop Environment](/workshop/setup)
+    - The instructor should [Setup Workshop Environment](setup.md)
     - The student should [Setup CLI and Terminal Shell](/workshop/setup#4.- (optional)-auto-configure-terminal-shell)
     - An user with cluster-admin (ie kubeadmin) needs to deploy a DB2 instance to be shared by all the users
 

--- a/docs/resources/workshop/cd.md
+++ b/docs/resources/workshop/cd.md
@@ -1,35 +1,25 @@
----
-title: Workshop - Promote an Application using CD with GitOps and ArgoCD
----
-
-!!!Todo
-    Reformat content
-    
-import Globals from 'gatsby-theme-carbon/src/templates/Globals';
-
-<PageDescription>
+# Promote an Application using CD with GitOps and ArgoCD
 
 Promote an Application using CD with GitOps and ArgoCD
 
-</PageDescription>
+Click on image below to launch video:
 
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/Fr85xbcM_es" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-
+[!["Workshop: CD/GitOps with ArgoCD"](http://img.youtube.com/vi/Fr85xbcM_es/0.jpg)](https://youtu.be/Fr85xbcM_es "Workshop: CD/GitOps with ArgoCD"){: target=_blank}
 
 1. Prerequisites
-    - Complete lab [Deploy an Application using CI Pipelines with Tekton](./ci).
+    - Complete lab [Deploy an Application using CI Pipelines with Tekton](ci.md).
 
 1. Set `TOOLKIT_USERNAME` environment variable replace `user1` with assigned usernames
-    ```bash
+
+    ```shell
     TOOLKIT_USERNAME=user1
 
     ```
 
 1. Set `TOOLKIT_PROJECT` environment variable replace `project1` or `projectx` based on user id assigned
-    ```bash
-    TOOLKIT_PROJECT=project1
 
+    ```shell
+    TOOLKIT_PROJECT=project1
     ```
 
 1. Verify Application is deployed in **QA**
@@ -41,28 +31,30 @@ Promote an Application using CD with GitOps and ArgoCD
     - Select **Developer** perspective, select project `${TOOLKIT_PROJECT}-qa` and then select **Topology** from the Console and see the application running
 
 1. Setup environment variable `GIT_OPS_URL` for the git url using the value from previous step or as following
-    ```bash
+
+    ```shell
     GIT_OPS_URL=http://${TOOLKIT_USERNAME}:password@$(oc get route -n tools gogs --template='{{.spec.host}}')/toolkit/gitops
     echo GIT_OPS_URL=${GIT_OPS_URL}
-
     ```
 
 1. Clone the git repository and change directory
-    ```bash
+
+    ```shell
     cd $HOME
     git clone $GIT_OPS_URL
     cd gitops
-
     ```
 
 1. Review the `qa` and `staging` directory in the git repository
-    ```bash
+
+    ```shell
     ls -l qa/
     ls -l staging/
     ```
 
 1. Promote the application from **QA** to **STAGING** by copying the app manifest files using git
-    ```bash
+
+    ```shell
     git config --local user.email "${TOOLKIT_USERNAME}@example.com"
     git config --local user.name "${TOOLKIT_USERNAME}"
 
@@ -71,7 +63,6 @@ Promote an Application using CD with GitOps and ArgoCD
     git add .
     git commit -m "Promote Application from QA to STAGING environment for $TOOLKIT_PROJECT"
     git push -u origin master
-
     ```
 
 1. Verify Application is deployed in **STAGING**
@@ -85,7 +76,8 @@ Promote an Application using CD with GitOps and ArgoCD
 
 1. Propose a change for the Application in **STAGING**
     - Update the replica count and create a new git branch in remote repo
-    ```bash
+
+    ```shell
     cat > staging/${TOOLKIT_PROJECT}/app/values.yaml <<EOF
     global: {}
     app:
@@ -98,8 +90,8 @@ Promote an Application using CD with GitOps and ArgoCD
     git checkout -b ${TOOLKIT_PROJECT}-pr1
     git commit -m "Update Application in ${TOOLKIT_PROJECT}-staging namespace"
     git push -u origin ${TOOLKIT_PROJECT}-pr1
-
     ```
+
     - Open Git Ops from Console Link
     - Select toolkit/gitops git repository
     - Create a Pull Request
@@ -118,4 +110,4 @@ Promote an Application using CD with GitOps and ArgoCD
     - Review in ArgoCD UI, it takes about 4 minutes to sync, you can click **Refresh**
     - Review in OpenShift Console, click the Deployment circle details shows 2 Pods.
 
-1. Congratulations you finished this activity, continue with the lab [Deploy a 3 tier Microservice using React, Node.js, and Java](./inventory)
+1. Congratulations you finished this activity, continue with the lab [Deploy a 3 tier Microservice using React, Node.js, and Java](inventory.md)

--- a/docs/resources/workshop/ci.md
+++ b/docs/resources/workshop/ci.md
@@ -1,22 +1,14 @@
----
-title: Workshop - Deploy an Application using CI Pipelines with Tekton
----
+# Deploy an Application using CI Pipelines with Tekton
+
+Click on image below to launch video:
+
+[!["Workshop: CI Pipelines with Tekton"](http://img.youtube.com/vi/V-BFLaPdoPo/0.jpg)](https://youtu.be/V-BFLaPdoPo "Workshop: CI Pipelines with Tekton"){: target=_blank}
 
 !!!Todo
-    Reformat content
-    
-import Globals from 'gatsby-theme-carbon/src/templates/Globals';
-
-<PageDescription>
-
-Deploy an Application using CI Pipelines with Tekton
-
-</PageDescription>
-
-<iframe width="560" height="315" src="https://www.youtube.com/embed/V-BFLaPdoPo" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    Fixup links - relative links are needed
 
 1. Prerequisites
-    - The instructor should [Setup Workshop Environment](/workshop/setup#3.-setup-ibm-cloud-native-toolkit-workshop)
+    - The instructor should [Setup Workshop Environment](setup.md)
     - The student should [Setup CLI and Terminal Shell](/workshop/setup#4-setup-cli-and-terminal-shell)
 
 1. Instructor will provide the following info:
@@ -24,27 +16,28 @@ Deploy an Application using CI Pipelines with Tekton
     - The username and password for OpenShift and Git Server (default values are user1, user2, etc.. for users and `password` for password).
 
 1. Set `TOOLKIT_USERNAME` environment variable replace `user1` or `userx` with assigned usernames
-    ```bash
-    TOOLKIT_USERNAME=user1
 
+    ```shell
+    TOOLKIT_USERNAME=user1
     ```
 
 1. **(Skip if using KubeAdmin or IBM Cloud)** Login into OpenShift using `oc`
     - If using IBM Cloud cluster then login with your IBM account email and IAM API Key or Token, if using a cluster that was configured with the workshop scripts outside IBM Cloud then use `user1` or respective assigned username, and the password is `password`
-    ```bash
+
+    ```shell
     oc login $OCP_URL -u $TOOLKIT_USERNAME -p password
     ```
 
 1. Set `TOOLKIT_PROJECT` environment variable replace `project1` or `projectx` based on username id assigned
-    ```bash
-    TOOLKIT_PROJECT=project1
 
+    ```shell
+    TOOLKIT_PROJECT=project1
     ```
 
 1. Create a project/namespace using your project as prefix, and `-dev` and suffix
-    ```bash
-    oc sync $TOOLKIT_PROJECT-dev
 
+    ```shell
+    oc sync $TOOLKIT_PROJECT-dev
     ```
 
 1. Fork application template git repo
@@ -57,24 +50,26 @@ Deploy an Application using CI Pipelines with Tekton
     - Click **Fork Repository**
 
 1. Setup environment variable `GIT_URL` for the git url using the value from previous step or as following
-    ```bash
+
+    ```shell
     GIT_URL=http://${TOOLKIT_USERNAME}:password@$(oc get route -n tools gogs --template='{{.spec.host}}')/$TOOLKIT_USERNAME/app
     echo GIT_URL=${GIT_URL}
-
     ```
 
 1. Clone the git repository and change directory
-    ```bash
+
+    ```shell
     cd $HOME
     git clone $GIT_URL
     cd app
-
     ```
 
 1. Create a pipeline for the application
-    ```bash
+
+    ```shell
     oc pipeline --tekton
     ```
+
     - Use down/up arrow and select `ibm-golang`
     - Hit Enter to enable image scanning
     - Open the url to see the pipeline running in the OpenShift Console
@@ -92,14 +87,14 @@ Deploy an Application using CI Pipelines with Tekton
 1. Open the application route url and try out the application using the swagger UI
 
 1. Make a change to the application in the git repository and see the pipeline running again from the Console.
-    ```bash
+
+    ```shell
     git config --local user.email "${TOOLKIT_USERNAME}@example.com"
     git config --local user.name "${TOOLKIT_USERNAME}"
     echo "A change to trigger a new PipelineRun $(date)" >> README.md
     git add .
     git commit -m "update readme"
     git push -u origin master
-
     ```
 
 1. Verify that change in Git Server and Git WebHook
@@ -114,8 +109,4 @@ Deploy an Application using CI Pipelines with Tekton
     - Open Git Ops from Console Link
     - Select toolkit/gitops git repository
 
-1. Congratulations you finished this lab, continue with lab [Promote an Application using CD with GitOps and ArgoCD](./cd)
-
-
-
-
+1. Congratulations you finished this lab, continue with lab [Promote an Application using CD with GitOps and ArgoCD](cd.md)

--- a/docs/resources/workshop/inventory.md
+++ b/docs/resources/workshop/inventory.md
@@ -1,23 +1,16 @@
----
-title: Workshop - Deploy a 3 tier Microservice using React, Node.js, and Java
----
-
-!!!Todo
-    Reformat content
-    
-import Globals from 'gatsby-theme-carbon/src/templates/Globals';
-
-<PageDescription>
+# Deploy a 3 tier Microservice using React, Node.js, and Java
 
 Deploy a 3 tier Microservice using React, Node.js, and Java
 
-</PageDescription>
+Click on image below to launch video:
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/gvuJi7qEZck" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+[!["Workshop: Microservice Inventory App"](http://img.youtube.com/vi/gvuJi7qEZck/0.jpg)](https://youtu.be/gvuJi7qEZck "Workshop: Microservice Inventory App"){: target=_blank}
 
+!!!Todo
+    Fixup links (relative links need to be used!)
 
 1. Prerequisites
-    - The instructor should [Setup Workshop Environment](/workshop/setup)
+    - The instructor should [Setup Workshop Environment](setup.md)
     - The student should [Setup CLI and Terminal Shell](/workshop/setup#4.-(optional)-auto-configure-terminal-shell)
 
 1. Instructor will provide the following info:
@@ -25,25 +18,29 @@ Deploy a 3 tier Microservice using React, Node.js, and Java
     - The username and password for OpenShift and Git Server (default values are user1, user2, etc.. for users and `password` for password).
 
 1. Set `TOOLKIT_USERNAME` environment variable replace `user1` with assigned usernames
-    ```bash
+
+    ```shell
     TOOLKIT_USERNAME=user1
 
     ```
 
 1. **(Skip if using KubeAdmin or IBM Cloud)** Login into OpenShift using `oc`
     - If using IBM Cloud cluster then login with your IBM account email and IAM API Key or Token, if using a cluster that was configured with the workshop scripts outside IBM Cloud then use `user1` or respective assigned username, and the password is `password`
-    ```bash
+
+    ```shell
     oc login $OCP_URL -u $TOOLKIT_USERNAME -p password
     ```
 
 1. Set `TOOLKIT_PROJECT` environment variable replace `project1` or `projectx` based on user id assigned
-    ```bash
+
+    ```shell
     TOOLKIT_PROJECT=project1
 
     ```
 
 1. Create a project/namespace using your project prefix, and `-dev` and suffix
-    ```
+
+    ```shell
     oc sync $TOOLKIT_PROJECT-dev
 
     ```
@@ -57,19 +54,20 @@ Deploy a 3 tier Microservice using React, Node.js, and Java
     - Click **Fork Repository**
 
 1. Setup environment variable `GIT_URL` for the git url using the value from previous step or as following
-    ```bash
+
+    ```shell
     GIT_REPO=inventory-management-svc-solution
     GIT_URL=http://${TOOLKIT_USERNAME}:password@$(oc get route -n tools gogs --template='{{.spec.host}}')/${TOOLKIT_USERNAME}/${GIT_REPO}
     echo GIT_URL=${GIT_URL}
-
     ```
 
 1. Create a pipeline for the application
-    ```
+
+    ```shell
     oc pipeline --tekton ${GIT_URL}#master -p scan-image=false
     ```
-    - Open the url to see the pipeline running in the OpenShift Console
 
+    - Open the url to see the pipeline running in the OpenShift Console
 
 1. Fork Inventory Sample Application TypeScript
     - Open Developer Dashboard from the OpenShift Console
@@ -80,17 +78,19 @@ Deploy a 3 tier Microservice using React, Node.js, and Java
 
 
 1. Setup environment variable `GIT_URL` for the git url using the value from previous step or as following
-    ```bash
+
+    ```shell
     GIT_REPO=inventory-management-bff-solution
     GIT_URL=http://${TOOLKIT_USERNAME}:password@$(oc get route -n tools gogs --template='{{.spec.host}}')/${TOOLKIT_USERNAME}/${GIT_REPO}
     echo GIT_URL=${GIT_URL}
-
     ```
 
 1. Create a pipeline for the application
-    ```
+
+    ```shell
     oc pipeline --tekton ${GIT_URL}#master -p scan-image=false
     ```
+
     - Open the url to see the pipeline running in the OpenShift Console
 
 1. Fork Inventory Sample Application React
@@ -101,63 +101,72 @@ Deploy a 3 tier Microservice using React, Node.js, and Java
     - Click **Fork Repository**
 
 1. Setup environment variable `GIT_URL` for the git url using the value from previous step or as following
-    ```bash
+
+    ```shell
     GIT_REPO=inventory-management-ui-solution
     GIT_URL=http://${TOOLKIT_USERNAME}:password@$(oc get route -n tools gogs --template='{{.spec.host}}')/${TOOLKIT_USERNAME}/${GIT_REPO}
     echo GIT_URL=${GIT_URL}
-
     ```
 
 1. Create a pipeline for the application
-    ```
+
+    ```shell
     oc pipeline --tekton ${GIT_URL}#master -p scan-image=false
     ```
+
     - Open the url to see the pipeline running in the OpenShift Console
 
 
 1. Setup environment variable `GIT_OPS_URL` for the git url using the value from previous step or as following
-    ```bash
+
+    ```shell
     GIT_OPS_URL=http://${TOOLKIT_USERNAME}:password@$(oc get route -n tools gogs --template='{{.spec.host}}')/toolkit/gitops
     echo GIT_OPS_URL=${GIT_OPS_URL}
-
     ```
 
 1. Clone the git repository and change directory
-    ```bash
+
+    ```shell
     cd $HOME
     git clone $GIT_OPS_URL gitops-inventory
     cd gitops-inventory
-
     ```
 
 1. Review the `qa` directory in the git repository, the directory might be empty if the 3 pipelines are not done yet.
-    ```bash
+
+    ```shell
     ls -l qa/${TOOLKIT_PROJECT}/
     ```
 
 1. Review the `qa` directory in the git repository again
-    ```bash
+
+    ```shell
     ls -l qa/${TOOLKIT_PROJECT}/
     ```
+
     You should see 3 directories
-    ```bash
+
+    ```text
     inventory-management-bff-solution/
     inventory-management-svc-solution/
     inventory-management-ui-solution/
     ```
 
-1. **Note**:If you don't see the directories, this is a good time for a coffee break of 15 minutes until all 3 Pipeline Runs are done.
+    !!!Note
+        If you don't see the directories, this is a good time for a coffee break of 15 minutes until all 3 Pipeline Runs are done.
 
 
 1. Once the Pipeline Runs are done, try to list the directories again. Each directory contains their corresponding yaml manifest files (ie Helm Chart)
-    ```bash
+
+    ```shell
     ls -l qa/${TOOLKIT_PROJECT}/inventory-management-bff-solution
     ls -l qa/${TOOLKIT_PROJECT}/inventory-management-svc-solution
     ls -l qa/${TOOLKIT_PROJECT}/inventory-management-ui-solution
     ```
 
 1. Promote the application to **QA** using git by creating a manifest yaml (ie Helm Chart) that leverage the Cloud Native Toolkit chart `argocd-config` to automate the creation of multiple ArgoCD Applications.
-    ```bash
+
+    ```shell
     git config --local user.email "${TOOLKIT_USERNAME}@example.com"
     git config --local user.name "${TOOLKIT_USERNAME}"
 
@@ -199,7 +208,6 @@ Deploy a 3 tier Microservice using React, Node.js, and Java
     git add .
     git commit -m "Add inventory application to gitops for project ${TOOLKIT_PROJECT}"
     git push -u origin master
-
     ```
 
 1. Register the Application in ArgoCD to deploy using GitOps
@@ -230,5 +238,3 @@ Deploy a 3 tier Microservice using React, Node.js, and Java
 1. Now the Microservices application is ready for the development teams, in some cases each team will own and work with the git repository for the microservices, while the gitops git repository is own by the operations team.
 
 1. Congratulations you finished this activity, continue with another lab in the workshop
-
-

--- a/docs/resources/workshop/setup.md
+++ b/docs/resources/workshop/setup.md
@@ -34,6 +34,9 @@ Create an OpenShift Cluster for example:
     !!!Note
       The username and password for Git Admin is `toolkit` `toolkit`
 
+!!!Todo
+    Shouls this be moved out of setup and into the student section of the workshop?
+
 ## 4. (Optional) Auto configure Terminal Shell
 
 - You can use [IBM Cloud Shell](https://cloud.ibm.com/shell), the [OpenLabs Shell](https://developer.ibm.com/openlabs/openshift) or your local workstation. More details in [Toolkit Dev Setup](https://cloudnativetoolkit.dev/getting-started/dev-env-setup) and [Toolkit CLI](https://cloudnativetoolkit.dev/getting-started/cli).

--- a/docs/resources/workshop/workshop.md
+++ b/docs/resources/workshop/workshop.md
@@ -2,24 +2,18 @@
 
 The Workshop is design to provide a quick way to try the methodology leveraging the tools that the Toolkit integrates.
 
+!!!Todo
+    Is this workshop Windows enabled - all instructions tend to use curl piped into sh?  Is Windows support needed?
+
 ## Agenda
 
-1. ![Setup Workshop Environment](./images/workshop.jpg){: width=30%}
+[![Setup Workshop Environment](./images/workshop.jpg){: width=30%}](setup.md) Setup Workshop Environment (*workshop admin only*)
 
-    Setup Workshop Environment (*Admin only students should jump to part 2*)
+[![Deploy an Application using CI Pipelines with Tekton](./images/ci-tekton.jpg){: width=30%}](ci.md) Deploy an Application using CI Pipelines with Tekton
 
-2. ![Deploy an Application using CI Pipelines with Tekton](./images/ci-tekton.jpg){: width=30%}
+[![Promote an Application using CD with GitOps and ArgoCD](./images/cd-argocd.jpg){: width=30%}](cd.md) Promote an Application using CD with GitOps and ArgoCD
 
-    Deploy an Application using CI Pipelines with Tekton
+[![Deploy a 3 tier Microservice using React, Node.js, and Java](./images/inventory.jpg){: width=30%}](inventory.md) Deploy a 3 tier Microservice using React, Node.js, and Java
 
-3. ![Promote an Application using CD with GitOps and ArgoCD](./images/cd-argocd.jpg){: width=30%}
+[![App Modernization with modern DevOps](./images/appmod.jpg){: width=30%}](appmod.md) App Modernization with modern DevOps
 
-    Promote an Application using CD with GitOps and ArgoCD
-
-4. ![Deploy a 3 tier Microservice using React, Node.js, and Java](./images/inventory.jpg){: width=30%}
-
-    Deploy a 3 tier Microservice using React, Node.js, and Java
-
-5. ![App Modernization with modern DevOps](./images/appmod.jpg){: width=30%}
-
-    App Modernization with modern DevOps


### PR DESCRIPTION
* remove gatsby based content

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* MkDocs based docs initial beta release

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* fix Google Analytics config

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Fix automation with mkdocs build command

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Update entrypoint.sh

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Updates dockerfile for mkdocs build

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>
Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* remove CNAME in publish beta workflow

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Add CNAME file to support GitHub pages

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Add workflow step to set beta CNAME for gh-pages

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* update permissions

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Update publish-beta.yaml

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Adds scripts to support dev process with mkdocs (#352)

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>
Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* fixup workshop formatting

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

* Added Docker instructions to Developer setup

Signed-off-by: Brian Innes <binnes@uk.ibm.com>

Co-authored-by: Sean Sundberg <seansund@us.ibm.com>